### PR TITLE
restrict frame-ancestors

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,15 @@ const nextConfig = {
           },
         ],
       },
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: 'frame-ancestors https://safe.astar.network',
+          },
+        ],
+      },
     ]
   },
   webpack: (config, options) => {


### PR DESCRIPTION
For security purposes, only Astar Safe is allowed as frame-ancestors.
https://safe.astar.network/